### PR TITLE
Add option to allow Optional Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The list of restrictions is as follows.
 - `{:enum, [...]}`: List of possible values for elements. It can be specified as `:integer` and `:string`.
 - `{:format, :datetime | :email}`: Validate by pre-defined format. It can be specified as `:string`.
 - `{:optional, boolean}`: If true, the child element of `%{...}` is not required. It can be only specified as the child element of `%{...}`.
+- `{:tolerant, boolean}`: If `true`, `"additionalProperties"` would be set to `true`, and will allow non-specified keys to be present in the child elements. It can be only specified as `%{...}`. Defaults to `false`.
 - `{:default, any}`: If the default value is specified and a field of the map is not given, the specified default value is set to the field. It can be only specified as the child element of `%{...}`.
 - `{:field, string}`: Corresponding JSON field name. It can be only specified as the child element of `%{...}`.
 

--- a/lib/simple_schema.ex
+++ b/lib/simple_schema.ex
@@ -64,7 +64,7 @@ defmodule SimpleSchema do
   end
   ```
   """
-  defmacro defschema(schema) do
+  defmacro defschema(schema, options \\ []) do
     enforce_keys =
       schema
       |> Enum.filter(fn {_key, value} ->
@@ -96,7 +96,7 @@ defmodule SimpleSchema do
 
       @impl SimpleSchema
       def schema(opts) do
-        {@simple_schema, opts}
+        {@simple_schema, unquote(options) ++ opts}
       end
 
       @impl SimpleSchema

--- a/lib/simple_schema/schema.ex
+++ b/lib/simple_schema/schema.ex
@@ -242,6 +242,7 @@ defmodule SimpleSchema.Schema do
 
   def to_json_schema({%{} = schema, opts}) do
     {nullable, opts} = Keyword.pop(opts, :nullable, false)
+    {tolerance, opts} = Keyword.pop(opts, :tolerant, false)
     raise_if_unexpected_opts(opts)
 
     properties =
@@ -268,7 +269,7 @@ defmodule SimpleSchema.Schema do
 
     xs = [
       {"type", types},
-      {"additionalProperties", false},
+      {"additionalProperties", tolerance},
       {"properties", properties}
     ]
 

--- a/lib/simple_schema/schema.ex
+++ b/lib/simple_schema/schema.ex
@@ -359,7 +359,7 @@ defmodule SimpleSchema.Schema do
     do_from_json(schema, value, opts)
   end
 
-  defp do_from_json(%{} = schema, map, _opts) do
+  defp do_from_json(%{} = schema, map, opts) do
     lookup_field =
       schema
       |> Enum.map(fn {atom_key, schema} ->
@@ -368,6 +368,14 @@ defmodule SimpleSchema.Schema do
         {field, atom_key}
       end)
       |> Enum.into(%{})
+
+    # drop unknownlookup_field keys from map if :tolerant opts is `true`
+    map =
+      if Keyword.get(opts, :tolerant, false) do
+        map |> Map.take(lookup_field |> Map.keys())
+      else
+        map
+      end
 
     # Use default value if :default opts is specified
     default_value =

--- a/test/simple_schema/schema_test.exs
+++ b/test/simple_schema/schema_test.exs
@@ -299,4 +299,25 @@ defmodule SimpleSchema.SchemaTest do
     assert {:ok, expected_json} == SimpleSchema.Schema.to_json(schema, expected)
     assert {:ok, expected_json} == SimpleSchema.Schema.to_json(schema, %{})
   end
+
+  test "Additional properties are not allowed without setting `tolerant: true`" do
+    schema = %{key1: %{key2: :integer}}
+    json = %{"key1" => %{"key2" => 100, "key3" => 200}}
+    assert {:error, _} = SimpleSchema.Schema.from_json(schema, json)
+  end
+
+  test "Additional properties are allowed by setting `tolerant: true`" do
+    schema = %{key1: {%{key2: :integer}, tolerant: true}}
+    json = %{"key1" => %{"key2" => 100, "key3" => 200}}
+    expected = %{key1: %{key2: 100}}
+    assert {:ok, expected} == SimpleSchema.Schema.from_json(schema, json)
+  end
+
+  test "Additional properties could be set on most outer objects" do
+    schema = { %{key1: %{key2: :integer}}, tolerant: true }
+    json1 = %{"key1" => %{"key2" => 100}, "key3" => 200}
+    json2 = %{"key1" => %{"key2" => 100, "key3" => 200}}
+    assert {:ok, _} = SimpleSchema.Schema.from_json(schema, json1)
+    assert {:error, _} = SimpleSchema.Schema.from_json(schema, json2)
+  end
 end


### PR DESCRIPTION
## What is this
This PR adds new option parameter `:tolerant` to switch if the JSON object could contain "optional parameters", aka parameters not defined in the schema. Defaults to `false`, which does not change the current way.
When `tolerant: true` passed, optional parameters are silently removed before verifying.
Passing options to the very top level (via macro) are also enabled by this PR.

## Why we need this
Currently simple schema does not have any options to allow optional parameters. Because of this, we get errors even if there are blindly added parameters by e.g. phoenix.

For example, if you want to replace this well known code generated by `phx.gen.html`:
```elixir
defmodule ServiceWeb.UserController do
  def create(conn, %{"user" => user_params}) do
    case Accounts.create_user(user_params) do
```
with this:

```elixir
defmodule ServiceWeb.UserController do
  defmodule UserSchema do
    import SimpleSchema, only: [defschema: 1]
    defschema [user: %{name: :string, age: FormInteger}]
  end

  def create(conn, json) do
    with {:ok, params} = SimpleSchema.from_json(UserSchema, json) do
      case Accounts.create_user(params.user) do
```

You cannot do this because phoenix's form sends JSON like this:

```elixir
%{
  "_csrf_token" => "EhM7GwkIGTokIiA0Rm4FAT1gKBcDEAAACXHrdokyLoAX3+5Yp5yy7g==", 
  "_utf8" => "✓", 
  "user" => %{"age" => "", "name" => ""}
}
```

The simplest way to go around is to set `"additionalProperties" => true,` in the schema's outer map.

## How to use
The above situation would be avoided by defining a schema like this;
```elixir
defmodule UserSchema do
  import SimpleSchema, only: [defschema: 2]

  defschema [
    user: %{
        name: :string,
        age: FormInteger,
      },
  ], tolerant: true   # <- the most outside option
end
```
The `defschema/1` macro became a `defschema/2` macro and receives options list as the second argument, which defaults to `[]`. When not using the macro-form, because `{schema, option}` was already a valid simple schema, we can just do `schema = {%{user: ...}, tolerant: true}`.
The `:tolerant` option affects only the current scope, so you can define schemas like this:

```elixir
defmodule UserSchema do
  import SimpleSchema, only: [defschema: 2]

  defschema [
    user: {
      %{
        name: :string,
        address: {
          %{country: :string, addr1: :string, addr2: :string},
          tolerant: false,  # will raise when not known keys given
        },
      },
      tolerant: true,  # won't raise with keys other than :name, :address
    },
  ]
end
```