### PR TITLE
SimpleSchema.Type.DateTime can be nullable

### DIFF
--- a/lib/simple_schema/type/date_time.ex
+++ b/lib/simple_schema/type/date_time.ex
@@ -18,16 +18,18 @@ defmodule SimpleSchema.Type.DateTime do
     do_from_json(schema, value, opts)
   end
 
+  defp do_to_json(_schema, nil, _opts), do: {:ok, ""}
+
+  defp do_to_json(_schema, value, _opts) do
+    {:ok, DateTime.to_iso8601(value)}
+  end
+
   defp do_from_json(_schema, nil, _opts), do: {:ok, nil}
+
   defp do_from_json(_schema, value, _opts) do
     case DateTime.from_iso8601(value) do
       {:ok, datetime, _} -> {:ok, datetime}
       {:error, reason} -> {:error, reason}
     end
-  end
-
-  defp do_to_json(_schema, nil, _opts), do: {:ok, ""}
-  defp do_to_json(_schema, value, _opts) do
-    {:ok, DateTime.to_iso8601(value)}
   end
 end

--- a/lib/simple_schema/type/date_time.ex
+++ b/lib/simple_schema/type/date_time.ex
@@ -2,20 +2,32 @@ defmodule SimpleSchema.Type.DateTime do
   @behaviour SimpleSchema
 
   @impl SimpleSchema
-  def schema(_opts) do
-    {:string, format: :datetime}
+  def schema(opts) do
+    merged_opts = Keyword.merge(opts, format: :datetime)
+
+    {:string, merged_opts}
   end
 
   @impl SimpleSchema
-  def from_json(_schema, value, _opts) do
+  def to_json(schema, value, opts) do
+    do_to_json(schema, value, opts)
+  end
+
+  @impl SimpleSchema
+  def from_json(schema, value, opts) do
+    do_from_json(schema, value, opts)
+  end
+
+  defp do_from_json(_schema, nil, _opts), do: {:ok, nil}
+  defp do_from_json(_schema, value, _opts) do
     case DateTime.from_iso8601(value) do
       {:ok, datetime, _} -> {:ok, datetime}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  @impl SimpleSchema
-  def to_json(_schema, value, _opts) do
+  defp do_to_json(_schema, nil, _opts), do: {:ok, ""}
+  defp do_to_json(_schema, value, _opts) do
     {:ok, DateTime.to_iso8601(value)}
   end
 end

--- a/lib/simple_schema/type/date_time.ex
+++ b/lib/simple_schema/type/date_time.ex
@@ -18,7 +18,7 @@ defmodule SimpleSchema.Type.DateTime do
     do_from_json(schema, value, opts)
   end
 
-  defp do_to_json(_schema, nil, _opts), do: {:ok, ""}
+  defp do_to_json(_schema, nil, _opts), do: {:ok, nil}
 
   defp do_to_json(_schema, value, _opts) do
     {:ok, DateTime.to_iso8601(value)}

--- a/test/simple_schema_test.exs
+++ b/test/simple_schema_test.exs
@@ -142,7 +142,6 @@ defmodule SimpleSchemaTest do
     )
   end
 
-
   defmodule MyStruct.Nullable do
     defstruct [:id, :datetime]
 
@@ -179,6 +178,7 @@ defmodule SimpleSchemaTest do
       id: 1,
       datetime: nil
     }
+
     normal_output = %MyStruct.Nullable{
       id: 1,
       datetime: datetime


### PR DESCRIPTION
Pass a nullable: true as an option in SimpleSchema.Type.DateTime,  It will raise an error.

```elixir
defmodule MyStruct do
    defstruct [:id, :datetime]

    @behaviour SimpleSchema

    @impl SimpleSchema
    def schema([]) do
      %{
        id: :integer,
        datetime: {SimpleSchema.Type.DateTime, nullable: true}
      }
    end
end
```

```elixir
[
 %{
    id: 1,
    datetime: nill
  }
]
```
```
> SimpleSchema.from_json(MyStruct, input)
** (RuntimeError) failed from_json/2: [{"Type mismatch. Expected String but got Null.", "#/0/start_at"}, {"Type mismatch. Expected String but got Null.", "#/1/start_at"}]
```


It seems to be caused by SimpleSchema.Type.DateTime.schema / 1 discarding `opts`

```elixir
def schema(_opts) do
   {:string, format: :datetime}
end
```

 So I fix it as follows.

```elixir
def schema(opts) do
    merged_opts = Keyword.merge(opts, format: :datetime)
    {:string, merged_opts}
end
```
