### PR TITLE
Use custom exceptions when convertion fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can also possible to add restriction to integers.
 
 ```elixir
 value = SimpleSchema.from_json!({:integer, minimum: 10, maximum: 20}, 5)
-# RuntimeError: [{"Expected the value to be >= 10", "#"}]
+# ** (SimpleSchema.FromJsonError) failed from_json/2: [{"Expected the value to be >= 10", "#"}]
 ```
 
 `{:integer, opts}` is also a simple schema.

--- a/lib/simple_schema.ex
+++ b/lib/simple_schema.ex
@@ -143,7 +143,7 @@ defmodule SimpleSchema do
         value
 
       {:error, reason} ->
-        raise "failed from_json/2: #{inspect(reason)}"
+        raise SimpleSchema.FromJsonError, reason: reason
     end
   end
 
@@ -184,7 +184,7 @@ defmodule SimpleSchema do
         json
 
       {:error, reason} ->
-        raise "failed to_json/3: #{inspect(reason)}"
+        raise SimpleSchema.ToJsonError, reason: reason
     end
   end
 end

--- a/lib/simple_schema/errors/from_json_error.ex
+++ b/lib/simple_schema/errors/from_json_error.ex
@@ -1,0 +1,13 @@
+defmodule SimpleSchema.FromJsonError do
+  defexception [:reason]
+
+  def message(exception) do
+    msg = "failed from_json/2"
+
+    if exception.reason != nil do
+      msg <> ": #{inspect(exception.reason)}"
+    else
+      msg
+    end
+  end
+end

--- a/lib/simple_schema/errors/to_json_error.ex
+++ b/lib/simple_schema/errors/to_json_error.ex
@@ -1,0 +1,13 @@
+defmodule SimpleSchema.ToJsonError do
+  defexception [:reason]
+
+  def message(exception) do
+    msg = "failed to_json/3"
+
+    if exception.reason != nil do
+      msg <> ": #{inspect(exception.reason)}"
+    else
+      msg
+    end
+  end
+end


### PR DESCRIPTION
## What is this
This PR aims to add `SimpleSchema`'s custom exceptions and use it when `from_json!/2` and `into_json!/3` fails.

## Why is this good
Currently `from_json!/2` raises a `RuntimeError` on failure. Although this is appreciative, it is not easy to use with `Plug`, where you can set custom return HTTP status by implementing `Plug.Exception`.
I think `simple_schema` plays natural with `Plug` or Phoenix, and since `from_json!/2` errors are mainly caused by the person who sent the JSON object, this should be captured separately from other `RuntimeError`s.

## Changes
### before
```ex
iex(1)> SimpleSchema.from_json!({:integer, minimum: 10, maximum: 20}, 5)
** (RuntimeError) failed from_json/2: [{"Expected the value to be >= 10", "#"}]
    (simple_schema) lib/simple_schema.ex:146: SimpleSchema.from_json!/3
```

### after
```ex
iex(1)> SimpleSchema.from_json!({:integer, minimum: 10, maximum: 20}, 5)
** (SimpleSchema.FromJsonError) failed from_json/2: [{"Expected the value to be >= 10", "#"}]
    (simple_schema) lib/simple_schema.ex:146: SimpleSchema.from_json!/3
```

I just rearranged what `RuntimeError` was doing to a separate module, but since the error struct has the member `reason` which will be a list of tuples, one can take out the error list by capturing the error (although usually you'd want to do `from_json/2`).

## Concerns
Guessing from the `type` and `validator` directories and files, I wondered if I should name the exceptions like `SimpleSchema.Error.ToJson`, but since it seemed placing the error namespace right under `SimpleSchema` will make it easier to use, I haven't followed the conventions here.
I want the maintainers to decide to or not to change it here; So it will help to have a review by you. 
thanks.