### PR TITLE
Elixir1.9.0へアップデート

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.8.0-otp-21
-erlang 21.1.1
+elixir 1.9.0-otp-22
+erlang 22.0.5

--- a/test/simple_schema_test.exs
+++ b/test/simple_schema_test.exs
@@ -301,6 +301,6 @@ defmodule SimpleSchemaTest do
       js = SimpleSchema.Schema.to_json_schema(schema, opts)
       update_in(js["properties"]["test"], &(Map.delete(&1, "maxItems")))
     end
-    {:ok, expected} = SimpleSchema.from_json(MyStruct5, json, [get_json_schema: get_json_schema])
+    {:ok, ^expected} = SimpleSchema.from_json(MyStruct5, json, [get_json_schema: get_json_schema])
   end
 end


### PR DESCRIPTION
### 概要
Elixir 1.9.0/OTP 22 へasdfで利用しているバージョンを更新しました。
特にテストで影響がなかったので、バージョンアップに関連しては修正を入れていません。

別途、テストが1件ちゃんとアサートできてなくてwarningになっていたのでついでに修正しています。
PRを分けたほうが良ければ対応するのでおっしゃってください