### PR TITLE
opts に :meta を許可

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,20 @@ assert value.point.y == 20
 - `{:default, any}`: フィールドのデフォルト値。渡された JSON にこのフィールドが存在しなかった場合はこの値になる。`%{...}` の子要素のみ指定可能。
 - `{:field, string}`: 対応する JSON のフィールド名。`%{...}` の子要素のみ指定可能。
 
+### メタ情報
+
+シンプルスキーマや制約以外の情報は `opts` に `:meta` キーを使って追加します。
+
+```elixir
+schema = %{
+  value: {:integer, optional: true},
+  point: %{
+    x: {:integer, meta: %{description: "x座標"}},
+    y: {:integer, meta: %{description: "y座標"}},
+  },
+}
+```
+
 ## `SimpleSchema` ビヘイビア
 
 `SimpleSchema` ビヘイビアを実装したモジュールは、シンプルスキーマになります。

--- a/lib/simple_schema/schema.ex
+++ b/lib/simple_schema/schema.ex
@@ -100,8 +100,13 @@ defmodule SimpleSchema.Schema do
 
   @primitive_types [:boolean, :integer, :number, :null, :string, :any]
 
-  defp raise_if_unexpected_opts([]), do: :ok
-  defp raise_if_unexpected_opts(field: _), do: :ok
+  defp raise_if_unexpected_opts(opts) do
+    {_, opts} = Keyword.pop(opts, :field)
+    {_, opts} = Keyword.pop(opts, :meta)
+    do_raise_if_unexpected_opts(opts)
+  end
+
+  defp do_raise_if_unexpected_opts([]), do: :ok
 
   defp to_types(type, nullable)
   defp to_types(type, true), do: [type, "null"]

--- a/test/simple_schema/schema_test.exs
+++ b/test/simple_schema/schema_test.exs
@@ -341,4 +341,30 @@ defmodule SimpleSchema.SchemaTest do
 
     assert expected == SimpleSchema.Schema.to_json_schema(schema, struct_converter: struct_converter)
   end
+
+  test "ignore meta" do
+    test_schema(
+      %{"type" => ["boolean", "null"]},
+      {:boolean, nullable: true, meta: %{description: "description"}}
+    )
+
+    test_schema(
+      %{"type" => "array", "items" => %{"type" => "string"}},
+      {[:string], meta: %{description: "description"}}
+    )
+
+    test_schema(
+      %{"type" => "string"},
+      {:string, field: "_field", meta: %{description: "description"}}
+    )
+
+    expected = SimpleSchema.Schema.to_json_schema(%{key1: %{key2: :integer}})
+    schema = %{
+      key1: {
+        %{key2: {:integer, meta: %{format: :int64}}},
+        meta: %{description: "description"}
+      }
+    }
+    test_schema(expected, schema)
+  end
 end

--- a/test/simple_schema_test.exs
+++ b/test/simple_schema_test.exs
@@ -303,4 +303,21 @@ defmodule SimpleSchemaTest do
     end
     {:ok, ^expected} = SimpleSchema.from_json(MyStruct5, json, [get_json_schema: get_json_schema])
   end
+
+  defmodule MyStruct6 do
+    import SimpleSchema, only: [defschema: 1]
+
+    defschema(
+      password: {:string, field: "_password", meta: %{description: "password", min_length: 15}}
+    )
+  end
+
+  test "meta の情報は無視される" do
+    # meta の min_length は無視される
+    expected = %MyStruct6{password: "abc"}
+    assert {:ok, expected} == SimpleSchema.from_json(MyStruct6, %{"_password" => "abc"})
+
+    expected_json = %{"_password" => "abc"}
+    assert {:ok, expected_json} == SimpleSchema.to_json(MyStruct6, expected)
+  end
 end


### PR DESCRIPTION
JSON の検証やデータの設定に使用しない情報を追加できるようにしました。
description などを書きたい場合に `:meta` をキーにして opts に指定します。