### PR TITLE
Fix and adjust misc HTML doc generation settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SimpleSchema
 
+<!-- MDOC !-->
+
 SimpleSchema は JSON の検証と各データ構造への設定を行うライブラリです。
 
 - [hex.pm](https://hex.pm/packages/simple_schema)

--- a/lib/simple_schema.ex
+++ b/lib/simple_schema.ex
@@ -1,7 +1,8 @@
 defmodule SimpleSchema do
-  @moduledoc """
-  #{File.read!("README.md")}
-  """
+  @moduledoc "README.md"
+             |> File.read!()
+             |> String.split("<!-- MDOC !-->")
+             |> Enum.fetch!(1)
 
   @type simple_schema :: SimpleSchema.Schema.simple_schema()
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,22 +1,22 @@
 defmodule SimpleSchema.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/gumi/simple_schema"
+  @version "1.2.0"
+  @name "SimpleSchema"
+
   def project do
     [
       app: :simple_schema,
-      version: "1.2.0",
+      name: @name,
+      version: @version,
       elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: "Validate JSON and store to a specified data structure",
-      package: [
-        maintainers: ["melpon", "kenichirow"],
-        licenses: ["Apache 2.0"],
-        links: %{"GitHub" => "https://github.com/gumi/simple_schema"}
-      ],
-      docs: [main: "SimpleSchema"],
       start_permanent: Mix.env() == :prod,
-      deps: deps(),
-      source_url: "https://github.com/gumi/simple_schema"
+      package: package(),
+      docs: docs(),
+      deps: deps()
     ]
   end
 
@@ -34,6 +34,25 @@ defmodule SimpleSchema.Mixfile do
       {:ex_json_schema, "~> 0.7"},
       {:ex_doc, "~> 0.22", only: :dev, runtime: false},
       {:memoize, "~> 1.3"}
+    ]
+  end
+
+  defp package do
+    [
+      maintainers: ["melpon", "kenichirow"],
+      licenses: ["Apache 2.0"],
+      links: %{
+        "Changelog" => "#{@source_url}/blob/master/CHANGELOG.md",
+        "GitHub" => @source_url
+      }
+    ]
+  end
+
+  defp docs do
+    [
+      main: @name,
+      source_ref: @version,
+      source_url: @source_url
     ]
   end
 end


### PR DESCRIPTION
This PR fixes and adjusts the HTML doc generation which includes:

- Remove repeated page title.
- Source reference to GitHub is based on tagged version instead of master branch.
- Clean up of module config (`mix.exs`).
- Add `Changelog` link to Hex module info page.

![image](https://user-images.githubusercontent.com/134518/95340168-6b900400-08e7-11eb-9ec8-626ac862d4d0.png)
